### PR TITLE
Feature/quiet flag

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -5,10 +5,10 @@ jobs:
     name: Build
     runs-on: macos-latest
     steps:
-      - name: Set up Go 1.12
+      - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.13
 
       - name: Check out source code
         uses: actions/checkout@v1
@@ -29,10 +29,10 @@ jobs:
     name: Test
     runs-on: macos-latest
     steps:
-      - name: Set up Go 1.12
+      - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.13
 
       - name: Check out source code
         uses: actions/checkout@v1

--- a/commands.go
+++ b/commands.go
@@ -66,6 +66,7 @@ func parseCommand() (Command, error) {
 	os.Args = newArgs
 
 	v.prepFlags()
+	flag.BoolVar(&config.Quiet, "quiet", false, "Suppress normal output to stdout.")
 
 	flag.Parse()
 	err := v.validateFlags()

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,9 @@ var ERROR int32 = 1
 // LogLevel represents the desired log verbosity
 var LogLevel int32 = STATUS
 
+// Quiet is a flag to suppress normal output to stdout, but not the log
+var Quiet bool = false
+
 // YAMLConfig contains the configuration values and yaml tags for the config file
 type YAMLConfig struct {
 	VcertUsername   string `yaml:"vcert_username"`

--- a/output/output.go
+++ b/output/output.go
@@ -40,7 +40,7 @@ func CenteredString(s string, w int) string {
 // Verbose writes a log entry if the log_level is VERBOSE or higher
 func Verbose(format string, a ...interface{}) {
 	if config.LogLevel >= config.VERBOSE {
-		fmt.Printf(format, a...)
+		printf(format, a...)
 		writeToLogFile(format, a...)
 	}
 }
@@ -48,24 +48,24 @@ func Verbose(format string, a ...interface{}) {
 // Info writes a log entry if the log_level is INFO or higher
 func Info(format string, a ...interface{}) {
 	if config.LogLevel >= config.INFO {
-		fmt.Printf(format, a...)
+		printf(format, a...)
 		writeToLogFile(format, a...)
 	}
 }
 
 // Print writes a log entry if the log_level is STATUS or higher
 func Print(format string, a ...interface{}) {
+	printf(format, a...)
 	if config.LogLevel >= config.STATUS {
-		fmt.Printf(format, a...)
 		writeToLogFile(format, a...)
 	}
 }
 
 // Status writes a log entry if the log_level is STATUS or higher
 func Status(format string, a ...interface{}) {
+	fmt.Print(Green)
+	printf(format, a...)
 	if config.LogLevel >= config.STATUS {
-		fmt.Print(Green)
-		fmt.Printf(format, a...)
 		writeToLogFile(format, a...)
 	}
 }
@@ -79,13 +79,20 @@ func HelpOutput(format string, a ...interface{}) {
 
 // Errorf writes a log entry if the log_level is ERROR or higher
 func Errorf(format string, a ...interface{}) {
+	fmt.Print(Red)
+	printf(format, a...)
 	if config.LogLevel >= config.ERROR {
-		fmt.Print(Red)
-		fmt.Printf(format, a...)
 		writeToLogFile(format, a...)
 	}
 }
 
 func writeToLogFile(format string, a ...interface{}) {
 	log.Printf(format, a...)
+}
+
+func printf(format string, a ...interface{}) {
+	// Suppress output if the quiet flag is set
+	if !config.Quiet {
+		fmt.Printf(format, a...)
+	}
 }


### PR DESCRIPTION
This PR adds a `-quiet` flag to the command-line, allowing the user to suppress normal output to stdout.  Also, STATUS-level output and PrettyPrint output are now sent to stdout regardless of the log_level setting in the config file (the log writer respects the log_level, though).  That way `cv list` will show output even if the log_level is at "error".  Use the `-quiet` flag to suppress this output, if you like.